### PR TITLE
Add random computer player

### DIFF
--- a/TicTacToeProject/Board.cs
+++ b/TicTacToeProject/Board.cs
@@ -40,27 +40,6 @@ namespace TicTacToeApp
             }
         }
 
-        // public string getBoardString()
-        // {
-        //     var boardString = "";
-        //     foreach (Space space in board)
-        //     {
-        //         var marker = space.marker;
-        //         var location = space.location;
-
-        //         if(marker == Symbols.EMPTY)
-        //         {
-        //             boardString += location.ToString() + " ";
-        //         }
-        //         else
-        //         {
-        //             boardString += marker + " ";
-        //         }
-        //     }
-        //     Console.WriteLine(boardString);
-        //     return boardString;
-        // }
-
         public Dictionary<int, string> createDictBoard()
         {
             var dictBoard = new Dictionary<int, string>();

--- a/TicTacToeProject/Board.cs
+++ b/TicTacToeProject/Board.cs
@@ -27,17 +27,9 @@ namespace TicTacToeApp
             return board.TrueForAll(space => !space.isSpaceEmpty());
         }
 
-        public bool placeMarker(int location, string playerMarker) 
+        public void placeMarker(int location, string playerMarker) 
         {
-            if (board[location - 1].isSpaceEmpty())
-            {
-                board[location - 1].marker = playerMarker;
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            board[location - 1].marker = playerMarker;
         }
 
         public Dictionary<int, string> createDictBoard()

--- a/TicTacToeProject/Board.cs
+++ b/TicTacToeProject/Board.cs
@@ -17,18 +17,15 @@ namespace TicTacToeApp
             }
         }
 
-
         public bool isEmpty()
         {
             return board.TrueForAll(space => space.isSpaceEmpty());
         }
 
-
         public bool isFilled()
         {
             return board.TrueForAll(space => !space.isSpaceEmpty());
         }
-
 
         public bool placeMarker(int location, string playerMarker) 
         {
@@ -43,6 +40,36 @@ namespace TicTacToeApp
             }
         }
 
+        // public string getBoardString()
+        // {
+        //     var boardString = "";
+        //     foreach (Space space in board)
+        //     {
+        //         var marker = space.marker;
+        //         var location = space.location;
+
+        //         if(marker == Symbols.EMPTY)
+        //         {
+        //             boardString += location.ToString() + " ";
+        //         }
+        //         else
+        //         {
+        //             boardString += marker + " ";
+        //         }
+        //     }
+        //     Console.WriteLine(boardString);
+        //     return boardString;
+        // }
+
+        public Dictionary<int, string> createDictBoard()
+        {
+            var dictBoard = new Dictionary<int, string>();
+            foreach (Space space in board)
+            {
+                dictBoard.Add(space.location, space.marker);
+            }
+            return dictBoard;
+        }
     }
 }
 

--- a/TicTacToeProject/ComputerPlayer.cs
+++ b/TicTacToeProject/ComputerPlayer.cs
@@ -20,16 +20,15 @@ namespace TicTacToeApp
             
         }
 
-        public bool isValidSpace(int location, Dictionary<int, string> board)
+        public bool isFilledSpace(int location, List<Space> board)
         {   
-            return board[location] == Symbols.EMPTY;
+            return board[location - 1].isSpaceFilled();
         }
 
-        public int getValidSpace(Dictionary<int, string> board)
+        public int getValidSpace(List<Space> board)
         {
-            
             var location = getRandomSpace();
-            while (!isValidSpace(location, board))
+            while (isFilledSpace(location, board))
             {   
                 location = getRandomSpace();
             }

--- a/TicTacToeProject/ComputerPlayer.cs
+++ b/TicTacToeProject/ComputerPlayer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+
+namespace TicTacToeApp
+{
+    public class ComputerPlayer
+    {
+        public string marker;
+
+        public ComputerPlayer(string marker = "o")
+        {
+            this.marker = marker;
+        }
+
+        public int getRandomSpace()
+        {
+            Random random = new Random();
+            return random.Next(1, 10);  
+            
+        }
+
+        public bool isValidSpace(int location, Dictionary<int, string> board)
+        {   
+            return board[location] == Symbols.EMPTY;
+        }
+
+
+
+        public int getValidSpace(Dictionary<int, string> board)
+        {
+            
+            var location = getRandomSpace();
+            while (!isValidSpace(location, board))
+            {   
+                location = getRandomSpace();
+            }
+            return location;
+        }
+
+    }
+}

--- a/TicTacToeProject/ComputerPlayer.cs
+++ b/TicTacToeProject/ComputerPlayer.cs
@@ -25,8 +25,6 @@ namespace TicTacToeApp
             return board[location] == Symbols.EMPTY;
         }
 
-
-
         public int getValidSpace(Dictionary<int, string> board)
         {
             

--- a/TicTacToeProject/HumanPlayer.cs
+++ b/TicTacToeProject/HumanPlayer.cs
@@ -1,12 +1,12 @@
 
 namespace TicTacToeApp
 {
-    public class Player
+    public class HumanPlayer
     {
         public string marker;
 
 
-        public Player(string marker)
+        public HumanPlayer(string marker)
         {
             this.marker = marker;
         }

--- a/TicTacToeProject/HumanPlayer.cs
+++ b/TicTacToeProject/HumanPlayer.cs
@@ -5,7 +5,6 @@ namespace TicTacToeApp
     {
         public string marker;
 
-
         public HumanPlayer(string marker)
         {
             this.marker = marker;

--- a/TicTacToeProject/Rules.cs
+++ b/TicTacToeProject/Rules.cs
@@ -18,7 +18,6 @@ namespace TicTacToeApp
             { 2, 5, 8 },
         };
 
-
         public bool checkIfWon(List<Space> board, string currentMarker)
         {
             List<string> tempRow = new List<string>();
@@ -40,12 +39,10 @@ namespace TicTacToeApp
             return isWon;
         }
 
-
         public bool checkIfDraw(Board board, string currentMarker)
         {
             return board.isFilled() && !checkIfWon(board.board, currentMarker);
         }
-
 
         public bool isRowComplete(List <string> row, string marker) 
         {

--- a/TicTacToeProject/Space.cs
+++ b/TicTacToeProject/Space.cs
@@ -10,13 +10,11 @@ namespace TicTacToeApp
         public int location;
         public string marker;
 
-
         public Space(int location, string marker = Symbols.EMPTY)
         {
             this.location = location;
             this.marker = marker;
         }
-
 
         public bool isSpaceEmpty()
         {

--- a/TicTacToeProject/Space.cs
+++ b/TicTacToeProject/Space.cs
@@ -21,5 +21,10 @@ namespace TicTacToeApp
             return marker == Symbols.EMPTY;
         }
 
+        public bool isSpaceFilled()
+        {
+            return marker != Symbols.EMPTY;
+        }
+
     }
 }  

--- a/TicTacToeProject/TicTacToe.cs
+++ b/TicTacToeProject/TicTacToe.cs
@@ -8,28 +8,43 @@ namespace TicTacToeApp
     public class TicTacToe
     {
         public Rules rules;
-        public Player playerOne;
-        public Player playerTwo;
-        public Board currentBoard;
-        public Player currentPlayer;
+        public HumanPlayer playerOne;
+        public HumanPlayer playerTwo;
+        public ComputerPlayer compPlayer;
 
-        public TicTacToe(string playerOneMarker = "X", string playerTwoMarker = "O")
+        public Board currentBoard;
+        
+        public string currentPlayerMarker;
+
+        public bool isSinglePlayer;
+
+        public TicTacToe(string playerOneMarker = "X", string playerTwoMarker = "O", bool isSinglePlayer = true)
         {
             Symbols.P1_MARKER = playerOneMarker;
             Symbols.P2_MARKER = playerTwoMarker;
             this.currentBoard = new Board();
             this.rules = new Rules();
-            this.playerOne = new Player(Symbols.P1_MARKER);
-            this.playerTwo = new Player(Symbols.P2_MARKER);
-            currentPlayer = this.playerOne;
+
+            if (isSinglePlayer) 
+            {
+                this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
+                this.compPlayer = new ComputerPlayer(Symbols.P2_MARKER);
+                this.isSinglePlayer = true;
+            }
+            else
+            {
+                this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
+                this.playerTwo = new HumanPlayer(Symbols.P2_MARKER);
+            }
+            this.currentPlayerMarker = this.playerOne.marker;
         }
 
         public bool turn(int location)
         {
-            moveMarker(location, currentPlayer.marker);
+            moveMarker(location, currentPlayerMarker);
             
-            bool notWon = !rules.checkIfWon(currentBoard.board, currentPlayer.marker);
-            bool notDrawn = !rules.checkIfDraw(currentBoard, currentPlayer.marker);
+            bool notWon = !rules.checkIfWon(currentBoard.board, currentPlayerMarker);
+            bool notDrawn = !rules.checkIfDraw(currentBoard, currentPlayerMarker);
             bool notOver = notWon && notDrawn;
 
             if (notOver)
@@ -43,9 +58,38 @@ namespace TicTacToeApp
             }
         }
 
+        // public bool computerTurn()
+        // {
+        //     var compsCurrentSpace = compPlayer.getValidSpace(currentBoard.createDictBoard());
+        //     moveMarker(compsCurrentSpace, compPlayer.marker);
+                
+        //         bool notWon = !rules.checkIfWon(currentBoard.board, compPlayer.marker);
+        //         bool notDrawn = !rules.checkIfDraw(currentBoard, compPlayer.marker);
+        //         bool notOver = notWon && notDrawn;
+
+        //         if (notOver)
+        //         {
+        //             switchPlayer();
+        //             return true;
+        //         }
+        //         else
+        //         {
+        //             return false;
+        //         }
+            
+        // }
+
+
         public void switchPlayer()
         {
-            currentPlayer = (currentPlayer == playerOne) ? playerTwo : playerOne;
+            if (isSinglePlayer) 
+            {
+                currentPlayerMarker = (currentPlayerMarker == playerOne.marker) ? compPlayer.marker : playerOne.marker;
+            }
+            else 
+            {
+                currentPlayerMarker = (currentPlayerMarker == playerOne.marker) ? playerTwo.marker : playerOne.marker;
+            }
         }
 
         public bool moveMarker(int location, string marker)

--- a/TicTacToeProject/TicTacToe.cs
+++ b/TicTacToeProject/TicTacToe.cs
@@ -37,6 +37,7 @@ namespace TicTacToeApp
 
         public bool turn(int location)
         {
+            
             moveMarker(location, currentPlayerMarker);
             
             bool notWon = !rules.checkIfWon(currentBoard.board, currentPlayerMarker);
@@ -66,9 +67,9 @@ namespace TicTacToeApp
             }
         }
 
-        public bool moveMarker(int location, string marker)
+        public void moveMarker(int location, string marker)
         {
-            return currentBoard.placeMarker(location, marker);
+            currentBoard.placeMarker(location, marker);
         }
 
     }

--- a/TicTacToeProject/TicTacToe.cs
+++ b/TicTacToeProject/TicTacToe.cs
@@ -10,24 +10,19 @@ namespace TicTacToeApp
         public Rules rules;
         public Player playerOne;
         public Player playerTwo;
-
         public Board currentBoard;
         public Player currentPlayer;
-
 
         public TicTacToe(string playerOneMarker = "X", string playerTwoMarker = "O")
         {
             Symbols.P1_MARKER = playerOneMarker;
             Symbols.P2_MARKER = playerTwoMarker;
-
             this.currentBoard = new Board();
             this.rules = new Rules();
-
             this.playerOne = new Player(Symbols.P1_MARKER);
             this.playerTwo = new Player(Symbols.P2_MARKER);
             currentPlayer = this.playerOne;
         }
-
 
         public bool turn(int location)
         {
@@ -36,7 +31,7 @@ namespace TicTacToeApp
             bool notWon = !rules.checkIfWon(currentBoard.board, currentPlayer.marker);
             bool notDrawn = !rules.checkIfDraw(currentBoard, currentPlayer.marker);
             bool notOver = notWon && notDrawn;
-            
+
             if (notOver)
             {
                 switchPlayer();
@@ -48,12 +43,10 @@ namespace TicTacToeApp
             }
         }
 
-
         public void switchPlayer()
         {
             currentPlayer = (currentPlayer == playerOne) ? playerTwo : playerOne;
         }
-
 
         public bool moveMarker(int location, string marker)
         {

--- a/TicTacToeProject/TicTacToe.cs
+++ b/TicTacToeProject/TicTacToe.cs
@@ -11,31 +11,29 @@ namespace TicTacToeApp
         public HumanPlayer playerOne;
         public HumanPlayer playerTwo;
         public ComputerPlayer compPlayer;
-
         public Board currentBoard;
         
         public string currentPlayerMarker;
-
         public bool isSinglePlayer;
 
-        public TicTacToe(string playerOneMarker = "X", string playerTwoMarker = "O", bool isSinglePlayer = true)
+        public TicTacToe(string playerOneMarker = "X", string playerTwoMarker = "O", bool isSinglePlayer = false)
         {
             Symbols.P1_MARKER = playerOneMarker;
             Symbols.P2_MARKER = playerTwoMarker;
             this.currentBoard = new Board();
             this.rules = new Rules();
-
+            this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
+                        
             if (isSinglePlayer) 
             {
-                this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
                 this.compPlayer = new ComputerPlayer(Symbols.P2_MARKER);
                 this.isSinglePlayer = true;
             }
             else
             {
-                this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
                 this.playerTwo = new HumanPlayer(Symbols.P2_MARKER);
             }
+
             this.currentPlayerMarker = this.playerOne.marker;
         }
 
@@ -57,27 +55,6 @@ namespace TicTacToeApp
                 return false;
             }
         }
-
-        // public bool computerTurn()
-        // {
-        //     var compsCurrentSpace = compPlayer.getValidSpace(currentBoard.createDictBoard());
-        //     moveMarker(compsCurrentSpace, compPlayer.marker);
-                
-        //         bool notWon = !rules.checkIfWon(currentBoard.board, compPlayer.marker);
-        //         bool notDrawn = !rules.checkIfDraw(currentBoard, compPlayer.marker);
-        //         bool notOver = notWon && notDrawn;
-
-        //         if (notOver)
-        //         {
-        //             switchPlayer();
-        //             return true;
-        //         }
-        //         else
-        //         {
-        //             return false;
-        //         }
-            
-        // }
 
 
         public void switchPlayer()

--- a/TicTacToeProject/TicTacToe.cs
+++ b/TicTacToeProject/TicTacToe.cs
@@ -12,7 +12,6 @@ namespace TicTacToeApp
         public HumanPlayer playerTwo;
         public ComputerPlayer compPlayer;
         public Board currentBoard;
-        
         public string currentPlayerMarker;
         public bool isSinglePlayer;
 
@@ -23,7 +22,7 @@ namespace TicTacToeApp
             this.currentBoard = new Board();
             this.rules = new Rules();
             this.playerOne = new HumanPlayer(Symbols.P1_MARKER);
-                        
+            
             if (isSinglePlayer) 
             {
                 this.compPlayer = new ComputerPlayer(Symbols.P2_MARKER);
@@ -33,7 +32,6 @@ namespace TicTacToeApp
             {
                 this.playerTwo = new HumanPlayer(Symbols.P2_MARKER);
             }
-
             this.currentPlayerMarker = this.playerOne.marker;
         }
 
@@ -55,7 +53,6 @@ namespace TicTacToeApp
                 return false;
             }
         }
-
 
         public void switchPlayer()
         {

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -9,6 +9,7 @@ namespace TicTacToeRunner
     {
         public TicTacToe newGame;
         public UserInterface gameUI;
+        public Options options;
         public bool isGameOver = false;
 
         static void Main(string[] args)
@@ -22,12 +23,11 @@ namespace TicTacToeRunner
             gameUI = new UserInterface();
             if (gameUI.startNewGame())
             {
-                var options = new Options(gameUI.setMarkers());
-                newGame = new TicTacToe(options.P1_MARKER, options.P2_MARKER);
+                options = new Options(gameUI.setMarkers());
+                newGame = new TicTacToe(options.P1_MARKER, options.P2_MARKER, options.IS_SINGLE_PLAYER);
                 while (!isGameOver)
                 {
-                    // playGameLoop();
-                    singlePlayerGameLoop();
+                    playGameLoop();
                 }
             }
         }
@@ -35,10 +35,28 @@ namespace TicTacToeRunner
         public void playGameLoop()
         {
             int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
-
             bool successfulTurn = newGame.turn(selectedSpace);
-
             if (successfulTurn)
+            {
+                if(options.IS_SINGLE_PLAYER)
+                {
+                    computerPlayerTurn();
+                }
+                else
+                {
+                    playGameLoop();
+                }
+            }
+            else
+            {
+                getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
+                isGameOver = true;
+            }
+        }
+
+        public void computerPlayerTurn()
+        {
+            if (newGame.turn(newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard())))
             {
                 playGameLoop();
             }
@@ -48,65 +66,6 @@ namespace TicTacToeRunner
                 isGameOver = true;
             }
         }
-
-
-        public void singlePlayerGameLoop()
-        {
-            int selectedHumanSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
-
-            bool successfulHumanTurn = newGame.turn(selectedHumanSpace);
-
-            if (successfulHumanTurn)
-            {
-                if (newGame.turn(newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard())))
-                {
-                    singlePlayerGameLoop();
-                }
-                else
-                {
-                    getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-                    isGameOver = true;
-                }
-            }
-            else
-            {
-                getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-                isGameOver = true;
-            }
-        }
-
-
-
-        
-        // public void singlePlayerGameLoop()
-        // {
-        //     int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
-        //     bool successfulTurn = newGame.turn(selectedSpace);
-
-        //     if (successfulTurn)
-        //     {
-        //         int computerSpace = newGame.compPlayer.getRandomSpace();
-        //         if (gameUI.isValidSpace(computerSpace.ToString(), newGame.currentBoard.createDictBoard()))
-        //         {
-        //             if (newGame.computerTurn(computerSpace))
-        //             {
-        //                 singlePlayerGameLoop();
-        //             }
-        //             else
-        //             {
-        //                 getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-        //                 isGameOver = true;
-        //             }
-        //         }
-        //     }
-        //     else
-        //     {
-        //         getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-        //         isGameOver = true;
-        //     }
-        // }
-
-
 
         public void getCompletedGameStatus(Board boardObject, string marker)
         {

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -26,25 +26,87 @@ namespace TicTacToeRunner
                 newGame = new TicTacToe(options.P1_MARKER, options.P2_MARKER);
                 while (!isGameOver)
                 {
-                    playGameLoop();
+                    // playGameLoop();
+                    singlePlayerGameLoop();
                 }
             }
         }
 
         public void playGameLoop()
         {
-            int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayer.marker);
+            int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
+
             bool successfulTurn = newGame.turn(selectedSpace);
+
             if (successfulTurn)
             {
                 playGameLoop();
             }
             else
             {
-                getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayer.marker);
+                getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
                 isGameOver = true;
             }
         }
+
+
+        public void singlePlayerGameLoop()
+        {
+            int selectedHumanSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
+
+            bool successfulHumanTurn = newGame.turn(selectedHumanSpace);
+
+            if (successfulHumanTurn)
+            {
+                if (newGame.turn(newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard())))
+                {
+                    singlePlayerGameLoop();
+                }
+                else
+                {
+                    getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
+                    isGameOver = true;
+                }
+            }
+            else
+            {
+                getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
+                isGameOver = true;
+            }
+        }
+
+
+
+        
+        // public void singlePlayerGameLoop()
+        // {
+        //     int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayerMarker);
+        //     bool successfulTurn = newGame.turn(selectedSpace);
+
+        //     if (successfulTurn)
+        //     {
+        //         int computerSpace = newGame.compPlayer.getRandomSpace();
+        //         if (gameUI.isValidSpace(computerSpace.ToString(), newGame.currentBoard.createDictBoard()))
+        //         {
+        //             if (newGame.computerTurn(computerSpace))
+        //             {
+        //                 singlePlayerGameLoop();
+        //             }
+        //             else
+        //             {
+        //                 getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
+        //                 isGameOver = true;
+        //             }
+        //         }
+        //     }
+        //     else
+        //     {
+        //         getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
+        //         isGameOver = true;
+        //     }
+        // }
+
+
 
         public void getCompletedGameStatus(Board boardObject, string marker)
         {

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -72,19 +72,28 @@ namespace TicTacToeRunner
 
         public void getCompletedGameStatus(Board boardObject, string marker)
         {
-            var isDraw = newGame.rules.checkIfDraw(boardObject, marker);
+            bool isDraw = newGame.rules.checkIfDraw(boardObject, marker);
+
             gameUI.displayBoard(newGame.currentBoard.createDictBoard());
             gameUI.displayWinOrDraw(isDraw, marker);
+            getSinglePlayerGameStatus(marker, isDraw);
+            isGameOver = true;
+        }
 
-            if ((options.IS_SINGLE_PLAYER != isDraw) && (marker == newGame.playerOne.marker))
+
+        public void getSinglePlayerGameStatus(string marker, bool isDraw)
+        {
+            bool isSinglePlayerAndNotDraw = options.IS_SINGLE_PLAYER != isDraw;
+            bool isHumansTurn = marker == newGame.playerOne.marker;
+
+            if ((isSinglePlayerAndNotDraw) && (isHumansTurn))
             {
                 gameUI.displaySinglePlayerGameStatus(true);
             }
-            else if (options.IS_SINGLE_PLAYER != isDraw)
+            else if (isSinglePlayerAndNotDraw)
             {
                 gameUI.displaySinglePlayerGameStatus(false);
             }
-            isGameOver = true;
         }
     }
 }

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -11,13 +11,11 @@ namespace TicTacToeRunner
         public UserInterface gameUI;
         public bool isGameOver = false;
 
-
         static void Main(string[] args)
         {
             var runner = new Runner();
             runner.createGame();
         }
-
 
         public void createGame()
         {
@@ -26,7 +24,6 @@ namespace TicTacToeRunner
             {
                 var options = new Options(gameUI.setMarkers());
                 newGame = new TicTacToe(options.P1_MARKER, options.P2_MARKER);
-
                 while (!isGameOver)
                 {
                     playGameLoop();
@@ -34,23 +31,10 @@ namespace TicTacToeRunner
             }
         }
 
-
-        public Dictionary<int, string> createPrimitiveBoard()
-        {
-            var primitiveBoard = new Dictionary<int, string>();
-            foreach (Space space in newGame.currentBoard.board)
-            {
-                primitiveBoard.Add(space.location, space.marker);
-            }
-            return primitiveBoard;
-        }
-
-
         public void playGameLoop()
         {
-            int selectedSpace = gameUI.getValidSpace(createPrimitiveBoard(), newGame.currentPlayer.marker);
+            int selectedSpace = gameUI.getValidSpace(newGame.currentBoard.createDictBoard(), newGame.currentPlayer.marker);
             bool successfulTurn = newGame.turn(selectedSpace);
-
             if (successfulTurn)
             {
                 playGameLoop();
@@ -62,12 +46,10 @@ namespace TicTacToeRunner
             }
         }
 
-
         public void getCompletedGameStatus(Board boardObject, string marker)
         {
             var isDraw = newGame.rules.checkIfDraw(boardObject, marker);
-
-            gameUI.displayBoard(createPrimitiveBoard());
+            gameUI.displayBoard(newGame.currentBoard.createDictBoard());
             gameUI.displayWinOrDraw(isDraw, marker);
         }
 

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -23,8 +23,11 @@ namespace TicTacToeRunner
             gameUI = new UserInterface();
             if (gameUI.startNewGame())
             {
-                options = new Options(gameUI.setMarkers());
+                var isSinglePlayer = gameUI.isSinglePlayerGame(gameUI.getTypeOfGame());
+                options = new Options(gameUI.setMarkers(), isSinglePlayer);
+
                 newGame = new TicTacToe(options.P1_MARKER, options.P2_MARKER, options.IS_SINGLE_PLAYER);
+
                 while (!isGameOver)
                 {
                     playGameLoop();
@@ -50,20 +53,20 @@ namespace TicTacToeRunner
             else
             {
                 getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-                isGameOver = true;
             }
         }
 
         public void computerPlayerTurn()
         {
-            if (newGame.turn(newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard())))
+            int compSelectedSpace = newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard());
+            if (newGame.turn(compSelectedSpace))
             {
+                gameUI.displayComputersMove(compSelectedSpace);
                 playGameLoop();
             }
             else
             {
                 getCompletedGameStatus(newGame.currentBoard, newGame.currentPlayerMarker);
-                isGameOver = true;
             }
         }
 
@@ -72,7 +75,16 @@ namespace TicTacToeRunner
             var isDraw = newGame.rules.checkIfDraw(boardObject, marker);
             gameUI.displayBoard(newGame.currentBoard.createDictBoard());
             gameUI.displayWinOrDraw(isDraw, marker);
-        }
 
+            if ((options.IS_SINGLE_PLAYER != isDraw) && (marker == newGame.playerOne.marker))
+            {
+                gameUI.displaySinglePlayerGameStatus(true);
+            }
+            else if (options.IS_SINGLE_PLAYER != isDraw)
+            {
+                gameUI.displaySinglePlayerGameStatus(false);
+            }
+            isGameOver = true;
+        }
     }
 }

--- a/TicTacToeRunner/Runner.cs
+++ b/TicTacToeRunner/Runner.cs
@@ -58,10 +58,11 @@ namespace TicTacToeRunner
 
         public void computerPlayerTurn()
         {
-            int compSelectedSpace = newGame.compPlayer.getValidSpace(newGame.currentBoard.createDictBoard());
+            int compSelectedSpace = newGame.compPlayer.getValidSpace(newGame.currentBoard.board);
+            gameUI.displayComputersMove(compSelectedSpace);
+
             if (newGame.turn(compSelectedSpace))
             {
-                gameUI.displayComputersMove(compSelectedSpace);
                 playGameLoop();
             }
             else
@@ -79,7 +80,6 @@ namespace TicTacToeRunner
             getSinglePlayerGameStatus(marker, isDraw);
             isGameOver = true;
         }
-
 
         public void getSinglePlayerGameStatus(string marker, bool isDraw)
         {

--- a/TicTacToeTests/BoardTest.cs
+++ b/TicTacToeTests/BoardTest.cs
@@ -23,7 +23,8 @@ namespace TicTacToeTests
         public void aBoardCanMarkaSpace()
         {
             var subject = new Board();
-            Assert.True(subject.placeMarker(5, P2_MARKER));
+            subject.placeMarker(5, P2_MARKER);
+            Assert.Equal(P2_MARKER, subject.board[4].marker);
         }
 
         [Fact]

--- a/TicTacToeTests/BoardTest.cs
+++ b/TicTacToeTests/BoardTest.cs
@@ -19,7 +19,6 @@ namespace TicTacToeTests
             Assert.True(subject.isEmpty());
         }
 
-
         [Fact]
         public void aBoardCanMarkaSpace()
         {
@@ -27,14 +26,12 @@ namespace TicTacToeTests
             Assert.True(subject.placeMarker(5, P2_MARKER));
         }
 
-
         [Fact]
         public void aNewBoardContainsInstancesOfSpaces()
         {
             var subject = new Board();
             Assert.Equal(9, subject.board[8].location);
         }
-
 
         [Fact]
         public void whenAMarkerIsPlacedTheBoardIsChanged()
@@ -44,7 +41,6 @@ namespace TicTacToeTests
             Assert.Equal(P1_MARKER, subject.board[4].marker);
         }
 
-
         [Fact]
         public void aSpecificLocationIsFilledAfterAMarkerIsPlaced()
         {
@@ -53,7 +49,6 @@ namespace TicTacToeTests
             Assert.False(subject.board[4].isSpaceEmpty());
         }
 
-
         [Fact]
         public void aBoardIsNotEmptyAfterAMarkerIsPlaced()
         {
@@ -61,7 +56,6 @@ namespace TicTacToeTests
             subject.placeMarker(5, P1_MARKER);
             Assert.False(subject.isEmpty());
         }
-
 
         [Fact]
         public void aBoardCanBeCompletelyFull()
@@ -79,7 +73,6 @@ namespace TicTacToeTests
 
             Assert.False(subject.isEmpty());
             Assert.True(subject.isFilled());
-
         }
 
     }

--- a/TicTacToeTests/ComputerPlayerTests.cs
+++ b/TicTacToeTests/ComputerPlayerTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+using System;
+using System.Collections.Generic;
+using TicTacToeApp;
+using TicTacToeUserInterface;
+
+namespace TicTacToeTests
+{
+    public class ComputerPlayerTest
+    {
+
+        [Fact]
+        public void aComputerCanGenerateANumberBetweenOneAndNine()
+        {
+            var subject = new Space(1);
+            Assert.True(subject.isSpaceEmpty());
+        }
+
+    }

--- a/TicTacToeTests/ComputerPlayerTests.cs
+++ b/TicTacToeTests/ComputerPlayerTests.cs
@@ -36,7 +36,6 @@ namespace TicTacToeTests
         public void aComputerPlayerCanGenerateARandomNumberBetweenOneAndNine()
         {
             var subject = new ComputerPlayer();
-
             Assert.InRange(subject.getRandomSpace(), 1, 9);
         }
 
@@ -44,7 +43,6 @@ namespace TicTacToeTests
         public void aComputerPlayerKnowIfSelectedSpaceIsValid()
         {
             var subject = new ComputerPlayer();
-
             Assert.True(subject.isValidSpace(1, MY_BOARD));
         }
 

--- a/TicTacToeTests/ComputerPlayerTests.cs
+++ b/TicTacToeTests/ComputerPlayerTests.cs
@@ -10,25 +10,11 @@ namespace TicTacToeTests
     {
         public const string P1_MARKER = "+";
         public const string P2_MARKER = "*";
-        
-        Dictionary<int, string> MY_BOARD = new Dictionary<int, string>()
-                                            {
-                                                {1,"_"},
-                                                {2,"_"},
-                                                {3,"_"},
-                                                {4,"_"},
-                                                {5,"_"},
-                                                {6,"_"},
-                                                {7,"_"},
-                                                {8,"_"},
-                                                {9,"_"}
-                                            };
 
         [Fact]
         public void aComputerPlayerInstantiatesWithAMarker()
         {
             var subject = new ComputerPlayer("X");
-            
             Assert.Equal("X", subject.marker);
         }
 
@@ -40,29 +26,29 @@ namespace TicTacToeTests
         }
 
         [Fact]
-        public void aComputerPlayerKnowIfSelectedSpaceIsValid()
+        public void aComputerPlayerKnowsIfSelectedSpaceIsAlreadyFilled()
         {
             var subject = new ComputerPlayer();
-            Assert.True(subject.isValidSpace(1, MY_BOARD));
+            var myBoard = new Board();
+            myBoard.placeMarker(1, P1_MARKER);
+            Assert.True(subject.isFilledSpace(1, myBoard.board));
         }
 
         [Fact]
         public void aComputerPlayerCanFindAValidMove()
         {
             var subject = new ComputerPlayer();
-            Dictionary<int, string> myBoard = new Dictionary<int, string>()
-                                            {
-                                                {1,"X"},
-                                                {2,"X"},
-                                                {3,"X"},
-                                                {4,"X"},
-                                                {5,"X"},
-                                                {6,"X"},
-                                                {7,"X"},
-                                                {8,"_"},
-                                                {9,"X"}
-                                            };
-            Assert.Equal(8, subject.getValidSpace(myBoard));
+            var myBoard = new Board();
+            myBoard.placeMarker(1, P1_MARKER);
+            myBoard.placeMarker(2, P1_MARKER);
+            myBoard.placeMarker(6, P1_MARKER);
+            myBoard.placeMarker(7, P1_MARKER);
+            myBoard.placeMarker(9, P1_MARKER);
+            myBoard.placeMarker(3, P2_MARKER);
+            myBoard.placeMarker(4, P2_MARKER);
+            myBoard.placeMarker(5, P2_MARKER);
+            
+            Assert.Equal(8, subject.getValidSpace(myBoard.board));
         }
 
     }

--- a/TicTacToeTests/ComputerPlayerTests.cs
+++ b/TicTacToeTests/ComputerPlayerTests.cs
@@ -8,12 +8,66 @@ namespace TicTacToeTests
 {
     public class ComputerPlayerTest
     {
+        public const string P1_MARKER = "+";
+        public const string P2_MARKER = "*";
+        
+        Dictionary<int, string> MY_BOARD = new Dictionary<int, string>()
+                                            {
+                                                {1,"_"},
+                                                {2,"_"},
+                                                {3,"_"},
+                                                {4,"_"},
+                                                {5,"_"},
+                                                {6,"_"},
+                                                {7,"_"},
+                                                {8,"_"},
+                                                {9,"_"}
+                                            };
 
         [Fact]
-        public void aComputerCanGenerateANumberBetweenOneAndNine()
+        public void aComputerPlayerInstantiatesWithAMarker()
         {
-            var subject = new Space(1);
-            Assert.True(subject.isSpaceEmpty());
+            var subject = new ComputerPlayer("X");
+            
+            Assert.Equal("X", subject.marker);
         }
 
+        [Fact]
+        public void aComputerPlayerCanGenerateARandomNumberBetweenOneAndNine()
+        {
+            var subject = new ComputerPlayer();
+
+            Assert.InRange(subject.getRandomSpace(), 1, 9);
+        }
+
+        [Fact]
+        public void aComputerPlayerKnowIfSelectedSpaceIsValid()
+        {
+            var subject = new ComputerPlayer();
+
+            Assert.True(subject.isValidSpace(1, MY_BOARD));
+        }
+
+        [Fact]
+        public void aComputerPlayerCanFindAValidMove()
+        {
+            var subject = new ComputerPlayer();
+            Dictionary<int, string> myBoard = new Dictionary<int, string>()
+                                            {
+                                                {1,"X"},
+                                                {2,"X"},
+                                                {3,"X"},
+                                                {4,"X"},
+                                                {5,"X"},
+                                                {6,"X"},
+                                                {7,"X"},
+                                                {8,"_"},
+                                                {9,"X"}
+                                            };
+            Assert.Equal(8, subject.getValidSpace(myBoard));
+        }
+
+        
+
     }
+}

--- a/TicTacToeTests/ComputerPlayerTests.cs
+++ b/TicTacToeTests/ComputerPlayerTests.cs
@@ -67,7 +67,5 @@ namespace TicTacToeTests
             Assert.Equal(8, subject.getValidSpace(myBoard));
         }
 
-        
-
     }
 }

--- a/TicTacToeTests/SpaceTest.cs
+++ b/TicTacToeTests/SpaceTest.cs
@@ -8,14 +8,12 @@ namespace TicTacToeTests
 {
     public class SpaceTest
     {
-
         [Fact]
         public void aNewSpaceIsEmpty()
         {
             var subject = new Space(1);
             Assert.True(subject.isSpaceEmpty());
         }
-
 
         [Fact]
         public void aSpacesMarkerCanBeChanged()
@@ -24,7 +22,6 @@ namespace TicTacToeTests
             subject.marker = "X";
             Assert.Equal("X", subject.marker);
         }
-
 
         [Fact]
         public void aMarkedSpaceIsNotEmpty()

--- a/TicTacToeTests/TTTTest.cs
+++ b/TicTacToeTests/TTTTest.cs
@@ -50,7 +50,8 @@ namespace TicTacToeTests
         public void aNewGameCanMarkaSpace()
         {
             var subject = new TicTacToe(P1_MARKER);
-            Assert.True(subject.moveMarker(3, P1_MARKER));
+            subject.moveMarker(3, P1_MARKER);
+            Assert.Equal(P1_MARKER, subject.currentBoard.board[2].marker);
         }
 
         [Fact]
@@ -238,7 +239,7 @@ namespace TicTacToeTests
             Console.WriteLine("Human's Move 1");
 
             // Computer's Turn
-            var compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            var compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.board);
             Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
             subject.turn(compsCurrentSpace);
             Assert.InRange(compsCurrentSpace, 2, 9);
@@ -252,7 +253,7 @@ namespace TicTacToeTests
             possibleMoves.Remove(possibleMoves[1]);
 
             // Computer's Turn
-            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.board);
             Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
 
             subject.turn(compsCurrentSpace);
@@ -265,7 +266,7 @@ namespace TicTacToeTests
             possibleMoves.Remove(possibleMoves[1]);
 
              // Computer's Turn
-            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.board);
             Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
             subject.turn(compsCurrentSpace);
             possibleMoves.Remove(compsCurrentSpace);

--- a/TicTacToeTests/TTTTest.cs
+++ b/TicTacToeTests/TTTTest.cs
@@ -8,7 +8,6 @@ namespace TicTacToeTests
 {
     public class TTTTest
     {
-
         public const string EMPTY = "_";
         public const string P1_MARKER = "+";
         public const string P2_MARKER = "o";
@@ -23,7 +22,6 @@ namespace TicTacToeTests
             Assert.Equal("O", subject.playerTwo.marker);
         }
 
-
         [Fact]
         public void twoPlayerGameInitializesProvidedPlayerMarkers()
         {
@@ -33,7 +31,6 @@ namespace TicTacToeTests
             Assert.Equal(P2_MARKER, subject.playerTwo.marker);
         }
         
-        
         [Fact]
         public void currentMarkerInTwoPlayerGameIsPlayerOne()
         {
@@ -41,7 +38,6 @@ namespace TicTacToeTests
 
             Assert.Equal(P1_MARKER, subject.currentPlayerMarker);
         }
-
 
         [Fact]
         public void gameInitializesWithNewInstanceOfBoard()
@@ -109,7 +105,6 @@ namespace TicTacToeTests
             Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
         }
 
-
         [Fact]
         public void aBoardWithThreeVerticalMarkersInARowWinsGame()
         {
@@ -168,21 +163,9 @@ namespace TicTacToeTests
             subject.turn(3);
             subject.turn(5);
 
-            // var ui = new UserInterface();
-            // ui.displayBoard(subject.currentBoard.createDictBoard());
-
             Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
             Assert.False(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
         }
-
-        // [Fact]
-        // public void singlePlayerGameInitializesWithDefaultPlayerMarkersXandO()
-        // {
-        //     var subject = new TicTacToe(isSinglePlayer = true);
-            
-        //     Assert.Equal("X", subject.playerOne.marker);
-        //     Assert.Equal("O", subject.compPlayer.marker);
-        // }
 
         [Fact]
         public void singlePlayerGameInitializesProvidedPlayerMarkers()
@@ -192,12 +175,11 @@ namespace TicTacToeTests
             Assert.Equal(P1_MARKER, subject.playerOne.marker);
             Assert.Equal(P2_MARKER, subject.compPlayer.marker);
         }
-                
+        
         [Fact]
         public void currentMarkerInSinglePlayerGameIsPlayerOne()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);
-
             Assert.Equal(P1_MARKER, subject.currentPlayerMarker);
         }
 
@@ -255,7 +237,6 @@ namespace TicTacToeTests
             subject.turn(1);
             Console.WriteLine("Human's Move 1");
 
-            
             // Computer's Turn
             var compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
             Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
@@ -270,7 +251,6 @@ namespace TicTacToeTests
             Console.WriteLine("Human's Move {0}", possibleMoves[1]);
             possibleMoves.Remove(possibleMoves[1]);
 
-
             // Computer's Turn
             compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
             Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
@@ -279,12 +259,10 @@ namespace TicTacToeTests
             possibleMoves.Remove(compsCurrentSpace);
             ui.displayBoard(subject.currentBoard.createDictBoard());
 
-
             // Human's Turn
             subject.turn(possibleMoves[1]);
             Console.WriteLine("Human's Move {0}", possibleMoves[1]);
             possibleMoves.Remove(possibleMoves[1]);
-            
 
              // Computer's Turn
             compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());

--- a/TicTacToeTests/TTTTest.cs
+++ b/TicTacToeTests/TTTTest.cs
@@ -11,10 +11,11 @@ namespace TicTacToeTests
 
         public const string EMPTY = "_";
         public const string P1_MARKER = "+";
-        public const string P2_MARKER = "*";
+        public const string P2_MARKER = "o";
+        public const bool IS_SINGLE_PLAYER = true;
 
         [Fact]
-        public void gameInitializesWithDefaultPlayerMarkersXandO()
+        public void twoPlayerGameInitializesWithDefaultPlayerMarkersXandO()
         {
             var subject = new TicTacToe();
             
@@ -24,12 +25,21 @@ namespace TicTacToeTests
 
 
         [Fact]
-        public void gameInitializesProvidedPlayerMarkers()
+        public void twoPlayerGameInitializesProvidedPlayerMarkers()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER);
 
             Assert.Equal(P1_MARKER, subject.playerOne.marker);
             Assert.Equal(P2_MARKER, subject.playerTwo.marker);
+        }
+        
+        
+        [Fact]
+        public void currentMarkerInTwoPlayerGameIsPlayerOne()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER);
+
+            Assert.Equal(P1_MARKER, subject.currentPlayerMarker);
         }
 
 
@@ -40,7 +50,6 @@ namespace TicTacToeTests
             Assert.NotNull(subject.currentBoard);
         }
 
-
         [Fact]
         public void aNewGameCanMarkaSpace()
         {
@@ -48,38 +57,34 @@ namespace TicTacToeTests
             Assert.True(subject.moveMarker(3, P1_MARKER));
         }
 
-
         [Fact]
-        public void aPlayerCanBeSwitched()
+        public void twoPlayerGameAPlayerCanBeSwitched()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER);           
-            Assert.Equal("+", subject.currentPlayer.marker);
+            Assert.Equal("+", subject.currentPlayerMarker);
             
             subject.switchPlayer();
-            Assert.Equal("*", subject.currentPlayer.marker);
+            Assert.Equal(P2_MARKER, subject.currentPlayerMarker);
         }
 
-
         [Fact]
-        public void aTurnCanBePlayedAndThePlayerIsSwitched()
+        public void twoPlayerGameATurnCanBePlayedAndThePlayerIsSwitched()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER);           
-            Assert.Equal("+", subject.currentPlayer.marker);
+            Assert.Equal("+", subject.currentPlayerMarker);
 
             subject.turn(1);
-            Assert.Equal("*", subject.currentPlayer.marker);
+            Assert.Equal(P2_MARKER, subject.currentPlayerMarker);
         }
 
-
         [Fact]
-        public void aRowOfThreeSameMarkersReturnsTrue()
+        public void RowOfThreeSameMarkersReturnsTrue()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER);           
             var row = new List<string> {P1_MARKER, P1_MARKER, P1_MARKER};
 
             Assert.True(subject.rules.isRowComplete(row, P1_MARKER));
         }
-
 
         [Fact]
         public void aBoardWithThreeHorizontalMarkersInARowWinsGame()
@@ -89,7 +94,7 @@ namespace TicTacToeTests
             subject.moveMarker(5, subject.playerOne.marker);
             subject.moveMarker(6, subject.playerOne.marker);
             
-            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayer.marker));
+            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
         }
 
 
@@ -101,7 +106,7 @@ namespace TicTacToeTests
             subject.moveMarker(5, subject.playerOne.marker);
             subject.moveMarker(9, subject.playerOne.marker);
 
-            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayer.marker));
+            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
         }
 
 
@@ -113,8 +118,8 @@ namespace TicTacToeTests
             subject.moveMarker(6, subject.playerOne.marker);
             subject.moveMarker(9, subject.playerOne.marker);
 
-            Assert.False(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayer.marker));
-            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayer.marker));
+            Assert.False(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
+            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
         }
 
         [Fact]
@@ -131,11 +136,11 @@ namespace TicTacToeTests
             subject.moveMarker(5, subject.playerTwo.marker);
             subject.moveMarker(8, subject.playerTwo.marker);
 
-            Assert.True(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayer.marker));
+            Assert.True(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
         }
 
         [Fact]
-        public void aDrawGameCanBePlayedWIthPlayersSwitching()
+        public void aTwoPlayerGameCanBeADrawWithPlayersSwitchingTurns()
         {
             var subject = new TicTacToe(P1_MARKER, P2_MARKER);           
             subject.turn(1);
@@ -148,8 +153,145 @@ namespace TicTacToeTests
             subject.turn(8);
             subject.turn(9);
 
-            Assert.False(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayer.marker));
-            Assert.True(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayer.marker));
+            Assert.False(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
+            Assert.True(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
+        }
+
+        [Fact]
+        public void aTwoPlayerGameCanBeWonWithPlayersSwitchingTurns()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER);           
+            subject.turn(1);
+            subject.turn(6);
+            subject.turn(9);
+            subject.turn(4);
+            subject.turn(3);
+            subject.turn(5);
+
+            // var ui = new UserInterface();
+            // ui.displayBoard(subject.currentBoard.createDictBoard());
+
+            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
+            Assert.False(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
+        }
+
+        // [Fact]
+        // public void singlePlayerGameInitializesWithDefaultPlayerMarkersXandO()
+        // {
+        //     var subject = new TicTacToe(isSinglePlayer = true);
+            
+        //     Assert.Equal("X", subject.playerOne.marker);
+        //     Assert.Equal("O", subject.compPlayer.marker);
+        // }
+
+        [Fact]
+        public void singlePlayerGameInitializesProvidedPlayerMarkers()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);
+
+            Assert.Equal(P1_MARKER, subject.playerOne.marker);
+            Assert.Equal(P2_MARKER, subject.compPlayer.marker);
+        }
+                
+        [Fact]
+        public void currentMarkerInSinglePlayerGameIsPlayerOne()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);
+
+            Assert.Equal(P1_MARKER, subject.currentPlayerMarker);
+        }
+
+        [Fact]
+        public void singlePlayerGameAPlayerCanBeSwitched()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);           
+            Assert.Equal("+", subject.currentPlayerMarker);
+            
+            subject.switchPlayer();
+            Assert.Equal(P2_MARKER, subject.currentPlayerMarker);
+        }
+
+        [Fact]
+        public void aSinglePlayerGameCanBeADrawWithMockedLocations()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);           
+            subject.turn(1);
+            subject.turn(3);
+            subject.turn(2);
+            subject.turn(4);
+            subject.turn(6);
+            subject.turn(5);
+            subject.turn(7);
+            subject.turn(8);
+            subject.turn(9);
+
+            Assert.False(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
+            Assert.True(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
+        }
+
+        [Fact]
+        public void aSinglePlayerGameCanBeWonWithMockedLocations()
+        {
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);           
+            subject.turn(1);
+            subject.turn(6);
+            subject.turn(9);
+            subject.turn(4);
+            subject.turn(3);
+            subject.turn(5);
+
+            Assert.True(subject.rules.checkIfWon(subject.currentBoard.board, subject.currentPlayerMarker));
+            Assert.False(subject.rules.checkIfDraw(subject.currentBoard, subject.currentPlayerMarker));
+        }
+
+        [Fact]
+        public void aSinglePlayerGameCanBePlayedWithComputerCreatedMoves()
+        {
+            var ui = new UserInterface();
+            var subject = new TicTacToe(P1_MARKER, P2_MARKER, IS_SINGLE_PLAYER);
+            var possibleMoves = new List<int>() { 1, 2, 3, 4, 5, 6, 8, 9 };
+
+            // Human's Turn
+            subject.turn(1);
+            Console.WriteLine("Human's Move 1");
+
+            
+            // Computer's Turn
+            var compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
+            subject.turn(compsCurrentSpace);
+            Assert.InRange(compsCurrentSpace, 2, 9);
+
+            possibleMoves.Remove(compsCurrentSpace);
+            ui.displayBoard(subject.currentBoard.createDictBoard());
+
+            // Human's Turn
+            subject.turn(possibleMoves[1]);
+            Console.WriteLine("Human's Move {0}", possibleMoves[1]);
+            possibleMoves.Remove(possibleMoves[1]);
+
+
+            // Computer's Turn
+            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
+
+            subject.turn(compsCurrentSpace);
+            possibleMoves.Remove(compsCurrentSpace);
+            ui.displayBoard(subject.currentBoard.createDictBoard());
+
+
+            // Human's Turn
+            subject.turn(possibleMoves[1]);
+            Console.WriteLine("Human's Move {0}", possibleMoves[1]);
+            possibleMoves.Remove(possibleMoves[1]);
+            
+
+             // Computer's Turn
+            compsCurrentSpace = subject.compPlayer.getValidSpace(subject.currentBoard.createDictBoard());
+            Console.WriteLine("Computer's Move {0}", compsCurrentSpace);
+            subject.turn(compsCurrentSpace);
+            possibleMoves.Remove(compsCurrentSpace);
+            ui.displayBoard(subject.currentBoard.createDictBoard());
         }
 
     }

--- a/TicTacToeTests/UserInterfaceTests.cs
+++ b/TicTacToeTests/UserInterfaceTests.cs
@@ -25,7 +25,6 @@ namespace TicTacToeTests
                                                 {9,"_"}
                                             };
 
-
         [Trait("Category", "UITest")]
         [Fact]
         public void markersCanBeSetWithUserProvidedSymbols()
@@ -35,7 +34,6 @@ namespace TicTacToeTests
 
             Assert.Equal(typeof(string), options.P1_MARKER.GetType());
         }
-
 
         [Trait("Category", "UITest")]
         [Fact]
@@ -49,7 +47,6 @@ namespace TicTacToeTests
             Assert.Equal("o", options.P2_MARKER);
         }
 
-
         [Trait("Category", "UITest")]
         [Fact]
         public void markersCannotBeTheSame()
@@ -59,7 +56,6 @@ namespace TicTacToeTests
             Assert.True(subject.isMarkerDifferent(P1_MARKER, P2_MARKER));
             Assert.False(subject.isMarkerDifferent(P1_MARKER, P1_MARKER));
         }
-
 
         [Trait("Category", "UITest")]
         [Fact]
@@ -72,7 +68,6 @@ namespace TicTacToeTests
             Assert.False(subject.isValidSpace("11", MY_BOARD));
             Assert.False(subject.isValidSpace("Q", MY_BOARD));   
         }
-
 
         [Trait("Category", "UITest")]
         [Fact]
@@ -88,6 +83,23 @@ namespace TicTacToeTests
         {
             var subject = new UserInterface();
             Assert.Contains("Players alternate placing", subject.displayInstructions());
+        }
+
+        [Trait("Category", "UITest")]
+        [Fact]
+        public void singlePlayerGameCanBeSelected()
+        {
+            var subject = new UserInterface();
+            var typeOfGame = "Y";
+            Assert.True(subject.isSinglePlayerGame(typeOfGame));
+        }
+
+        [Trait("Category", "UITest")]
+        [Fact]
+        public void userCanEnterYesIfSinglePlayerGame()
+        {
+            var subject = new UserInterface();            
+            Assert.Equal(("Y"), subject.getTypeOfGame());
         }
 
     }

--- a/TicTacToeUserInterface/Options.cs
+++ b/TicTacToeUserInterface/Options.cs
@@ -3,19 +3,21 @@ using TicTacToeApp;
 
 namespace TicTacToeUserInterface
 {
-  public class Options {
+    public class Options {
 
-    public string P1_MARKER;
-    public string P2_MARKER;
+        public string P1_MARKER;
+        public string P2_MARKER;
 
-    public const string EMPTY = Symbols.EMPTY;
-    public const int BOARD_SIZE = Symbols.BOARD_SIZE;
+        public const string EMPTY = Symbols.EMPTY;
+        public const int BOARD_SIZE = Symbols.BOARD_SIZE;
+        public bool IS_SINGLE_PLAYER;
 
-    public Options (Tuple<string, string> markers)
-    {
-      this.P1_MARKER = markers.Item1;
-      this.P2_MARKER = markers.Item2;
+        public Options (Tuple<string, string> markers, bool isSinglePlayer = false)
+        {
+            this.P1_MARKER = markers.Item1;
+            this.P2_MARKER = markers.Item2;
+            this.IS_SINGLE_PLAYER = isSinglePlayer;
+        }
+
     }
-
-  }
 }

--- a/TicTacToeUserInterface/UserInterface.cs
+++ b/TicTacToeUserInterface/UserInterface.cs
@@ -10,7 +10,6 @@ namespace TicTacToeUserInterface
         {
             Console.WriteLine("Are you ready to play Tic Tac Toe? Y/N");
             string answer = Console.ReadLine();
-
             if (answer == "Y")
             {
                 displayInstructions();
@@ -28,7 +27,6 @@ namespace TicTacToeUserInterface
             }
         }
 
-
         public int getValidSpace(Dictionary<int, string> board, string marker)
         {
             displayBoard(board);
@@ -41,7 +39,6 @@ namespace TicTacToeUserInterface
             return Convert.ToInt32(location);
         }
         
-
         public bool isValidSpace(string location, Dictionary<int, string> board)
         {   
             try
@@ -63,13 +60,11 @@ namespace TicTacToeUserInterface
             }
         }
 
-
         public string getSpace(string marker)
         {
             Console.WriteLine("Player \"{0}\" please enter an empty space between 1 - {1}:", marker, Convert.ToInt32(Options.BOARD_SIZE));
             return Console.ReadLine();
         }
-
 
         public void displayWinOrDraw(bool isDraw, string winnersMarker)
         {
@@ -83,30 +78,25 @@ namespace TicTacToeUserInterface
             }
         }
 
-
         public Tuple<string, string> setMarkers()
         {
             Console.Write("Player One - ");
             var markerOne = chooseMarker();
             Console.Write("Player Two - ");
             var markerTwo = chooseMarker();
-
             while (!isMarkerDifferent(markerOne, markerTwo))
             {
                 Console.WriteLine("Please select a different symbol from Player One.");
                 markerTwo = chooseMarker();
             }
             Console.WriteLine("\nA new game has been started!\n\nPlayer One - Your Marker is {0}\nPlayer Two - Your Marker is {1}\n", markerOne, markerTwo);
-
             return Tuple.Create(markerOne, markerTwo);
         }
-
 
         public bool isMarkerDifferent(string marker1, string marker2)
         {
             return marker1 != marker2;
         }
-
 
         public string chooseMarker()
         {
@@ -122,7 +112,6 @@ namespace TicTacToeUserInterface
             }
         }
 
-
         public string displayBoard(Dictionary<int, string> board)
         {
             var displayBoard = "  ———————————  \n | ";
@@ -130,7 +119,6 @@ namespace TicTacToeUserInterface
             {
                 var marker = space.Value;
                 var location = space.Key;
-
                 if(marker == Options.EMPTY)
                 {
                     displayBoard += location.ToString() + " | ";
@@ -146,7 +134,6 @@ namespace TicTacToeUserInterface
             Console.WriteLine(displayBoard);
             return displayBoard;
         }
-
 
         public string displayInstructions()
         {

--- a/TicTacToeUserInterface/UserInterface.cs
+++ b/TicTacToeUserInterface/UserInterface.cs
@@ -27,6 +27,32 @@ namespace TicTacToeUserInterface
             }
         }
 
+        public string getTypeOfGame()
+        {
+            Console.WriteLine("Do you want to play against the computer? Y/N");            
+            string answer = Console.ReadLine();            
+            if (answer == "Y" || answer == "N")
+            {
+                return answer;
+            }
+            else
+            {
+                Console.WriteLine("Please enter Y or N only.");
+                return getTypeOfGame();
+            }
+        }
+
+        public void displayComputersMove(int compSpace)
+        {
+            
+            Console.WriteLine("\nThe computer selected space {0}.", compSpace.ToString());
+        }
+
+        public bool isSinglePlayerGame(string isSinglePlayer)
+        {
+            return isSinglePlayer == "Y" ? true : false;
+        }
+
         public int getValidSpace(Dictionary<int, string> board, string marker)
         {
             displayBoard(board);
@@ -62,7 +88,7 @@ namespace TicTacToeUserInterface
 
         public string getSpace(string marker)
         {
-            Console.WriteLine("Player \"{0}\" please enter an empty space between 1 - {1}:", marker, Convert.ToInt32(Options.BOARD_SIZE));
+            Console.Write("Player \"{0}\" please enter an empty space between 1 - {1}: ", marker, Convert.ToInt32(Options.BOARD_SIZE));
             return Console.ReadLine();
         }
 
@@ -74,15 +100,28 @@ namespace TicTacToeUserInterface
             }
             else
             {
-                Console.WriteLine("Player \"{0}\" has WON!", winnersMarker);    
+                Console.WriteLine("\"{0}\" has WON!", winnersMarker);    
+            }
+        }
+
+        public void displaySinglePlayerGameStatus(bool isWon)
+        {
+            if(isWon)
+            {
+                Console.WriteLine("Congrats you are the winner!!");
+            }
+            else
+            {
+                Console.WriteLine("Oh no, the computer is the winner, better luck next time.");
             }
         }
 
         public Tuple<string, string> setMarkers()
         {
-            Console.Write("Player One - ");
+            Console.Write("Please choose a symbol for Player One: ");
             var markerOne = chooseMarker();
-            Console.Write("Player Two - ");
+            Console.Write("Please choose a symbol for Player Two: ");
+
             var markerTwo = chooseMarker();
             while (!isMarkerDifferent(markerOne, markerTwo))
             {
@@ -100,7 +139,6 @@ namespace TicTacToeUserInterface
 
         public string chooseMarker()
         {
-            Console.WriteLine("Please choose a symbol for your marker:");
             string marker = Console.ReadLine();
             if(marker == "")
             {


### PR DESCRIPTION
The game is playable as single player or two human players. I made it so that you can still choose markers for both players.

I built one crazy test (`aSinglePlayerGameCanBePlayedWithComputerCreatedMoves` in `TTTTest.cs`) I was checking to see if the computer's turn executed correctly before I figured out how to add the computer's turn to the game play loop in the runner.  It doesn't really test anything, and only gives visual feedback. And I already tested that the computer can only choose available spaces on the board - (`aComputerPlayerCanFindAValidMove` in `ComputerPlayerTest.cs`). I left it on this PR as I was wondering if this would could kinda be an acceptance test rather than a unit test? And therefore should something like this exist, but somewhere else...?

Also I now have two methods to check if a space is empty (in `ComputerPlayer.cs` and `UserInterface.cs`).  I'm thinking that maybe the Board should manage this, or maybe the Rules? Or actually, I'm just now thinking I should just be using `Space.isSpaceEmpty(`.